### PR TITLE
feat(example): add Chupacabra POV video script

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Additional information about the license model can be found in the [docs](https:
 
 Found a bug 🐛 or have a feature idea ✨? Check our [Contributing Guide](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) to get started.
 
+## Example: Create a Chupacabra POV video
+
+This repository now contains a simple FFmpeg script to help you create a three‑minute Chupacabra video in first‑person GoPro style.
+
+1. Place your raw GoPro footage at `assets/gopro.mp4`.
+2. Add a transparent image of the Chupacabra as `assets/chupacabra.png`.
+3. Run `node scripts/createChupacabraPovVideo.mjs`.
+
+The script overlays the provided Chupacabra image while cropping the top portion so the face stays hidden. The resulting file `chupacabra_pov.mp4` will be exactly three minutes long.
+
 ## Join the Team
 
 Want to shape the future of automation? Check out our [job posts](https://n8n.io/careers) and join our team!

--- a/scripts/createChupacabraPovVideo.mjs
+++ b/scripts/createChupacabraPovVideo.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+
+const input = process.argv[2] || 'assets/gopro.mp4';
+const overlay = process.argv[3] || 'assets/chupacabra.png';
+const output = process.argv[4] || 'chupacabra_pov.mp4';
+
+if (!existsSync(input)) {
+  console.error(`Input video not found: ${input}`);
+  process.exit(1);
+}
+
+if (!existsSync(overlay)) {
+  console.error(`Overlay image not found: ${overlay}`);
+  process.exit(1);
+}
+
+const cmd = [
+  'ffmpeg',
+  '-i', input,
+  '-loop', '1',
+  '-i', overlay,
+  '-filter_complex',
+  "[1:v]crop=iw:ih*0.6:0:ih*0.4[ov];[0:v][ov]overlay=(main_w-w)/2:(main_h-h)/2",
+  '-t', '180',
+  '-c:a', 'copy',
+  '-y',
+  output,
+].join(' ');
+
+execSync(cmd, { stdio: 'inherit' });


### PR DESCRIPTION
## Summary
- replace Bigfoot video example with Chupacabra
- update FFmpeg script and README

## Testing
- `pnpm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882aeb3dd088322aaee4665785c1774

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a script to generate a three-minute Chupacabra POV video using FFmpeg, along with instructions in the README.

### Why are these changes being made?

The script and documentation provide users with a novel example of using FFmpeg for video editing tasks, enhancing the repository's utility and appeal by offering a fun, creative example. This approach utilizes existing FFmpeg capabilities to demonstrate multimedia processing and scripting in a straightforward manner.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->